### PR TITLE
Router refactor

### DIFF
--- a/Router/Router.spec.ts
+++ b/Router/Router.spec.ts
@@ -14,8 +14,7 @@ describe("Router", () => {
   let router: Router;
 
   beforeEach(() => {
-    router = new Router();
-    configureDefaults(router);
+    router = createRouter();
   });
 
   it("exists.", () => {
@@ -23,6 +22,8 @@ describe("Router", () => {
   });
 
   describe(".route()", () => {
+    testForDecorator(new Router().route, "GET", "/");
+
     it("throws error if invalid HTTP method provided.", () => {
       expect(() => {
         // @ts-ignore
@@ -42,6 +43,8 @@ describe("Router", () => {
   });
 
   describe(".static()", () => {
+    testForDecorator(new Router().static);
+
     it("is defined", () => {
       expect(router.static).toBeDefined();
     });
@@ -66,7 +69,16 @@ describe("Router", () => {
   });
 });
 
-function configureDefaults(router: Router) {
-  router.notFound(() => "not found");
-  router.static("./Router/public_test");
+function testForDecorator(method: Function, ...args: any) {
+  it("returns a Router object instance", () => {
+    expect(getStringyProperties(method.apply(new Router(), args))).toBe(
+      getStringyProperties(new Router())
+    );
+  });
 }
+
+const getStringyProperties = (object: Object) =>
+  JSON.stringify(Object.getOwnPropertyNames(object));
+
+const createRouter = () =>
+  new Router().notFound(() => "not found").static("./Router/public_test");

--- a/Router/Router.spec.ts
+++ b/Router/Router.spec.ts
@@ -50,7 +50,7 @@ describe("Router", () => {
     });
 
     it("responds 404 if resource not present", async () => {
-      const res = await router.response(
+      const res = await router.fetch(
         new Request(baseURL + endpoints.fail) as TypedRequest
       );
       expect(res.status).toBe(404);
@@ -59,7 +59,7 @@ describe("Router", () => {
     describe("responds 200 if present with", () => {
       "js html".split(" ").forEach((ext) => {
         it(`${ext} extension.`, async () => {
-          const res = await router.response(
+          const res = await router.fetch(
             new Request(`${baseURL}${endpoints.success}${ext}`) as TypedRequest
           );
           expect(res.status).toBe(200);

--- a/Router/Router.ts
+++ b/Router/Router.ts
@@ -16,7 +16,7 @@ export class Router {
       DELETE: new Map(),
     };
 
-    this.response = this.response.bind(this);
+    this.fetch = this.fetch.bind(this);
   }
 
   route(method: Method, endpoint: string, callback: () => any): Router {
@@ -33,7 +33,7 @@ export class Router {
     return this;
   }
 
-  async response({ method, url }: TypedRequest) {
+  async fetch({ method, url }: TypedRequest) {
     const { pathname } = new URL(url);
     const [, ext] = pathname.split("/").pop().split(".");
 

--- a/Router/Router.ts
+++ b/Router/Router.ts
@@ -15,18 +15,22 @@ export class Router {
       PATCH: new Map(),
       DELETE: new Map(),
     };
+
+    this.response = this.response.bind(this);
   }
 
-  route(method: Method, endpoint: string, callback: () => any) {
+  route(method: Method, endpoint: string, callback: () => any): Router {
     try {
       this.routes[method].set(endpoint, callback);
+      return this;
     } catch (TypeError) {
       throw `Invalid method, "${method}"`;
     }
   }
 
-  notFound(errorCallback: () => BodyInit) {
+  notFound(errorCallback: () => BodyInit): Router {
     this.#notFound = new Response(errorCallback(), { status: 404 });
+    return this;
   }
 
   async response({ method, url }: TypedRequest) {
@@ -50,7 +54,8 @@ export class Router {
     return this.#notFound;
   }
 
-  static(dirPath: string) {
+  static(dirPath: string): Router {
     this.#static = dirPath;
+    return this;
   }
 }

--- a/Router/Router.ts
+++ b/Router/Router.ts
@@ -19,7 +19,7 @@ export class Router {
     this.fetch = this.fetch.bind(this);
   }
 
-  route(method: Method, endpoint: string, callback: () => any): Router {
+  route(method: Method, endpoint: string, callback: () => any) {
     try {
       this.routes[method].set(endpoint, callback);
       return this;
@@ -28,7 +28,7 @@ export class Router {
     }
   }
 
-  notFound(errorCallback: () => BodyInit): Router {
+  notFound(errorCallback: () => BodyInit) {
     this.#notFound = new Response(errorCallback(), { status: 404 });
     return this;
   }
@@ -54,7 +54,7 @@ export class Router {
     return this.#notFound;
   }
 
-  static(dirPath: string): Router {
+  static(dirPath: string) {
     this.#static = dirPath;
     return this;
   }

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@ import { Router } from "./Router/Router";
 console.log("Starting server...");
 
 const port = 3000;
-const { response } = new Router()
+const { fetch } = new Router()
   .static("./public")
   .notFound(() => "404, not found")
   .route("GET", "/", () => {
@@ -11,7 +11,7 @@ const { response } = new Router()
   });
 
 export default {
-  fetch: response,
+  fetch,
   port,
 };
 

--- a/main.ts
+++ b/main.ts
@@ -3,17 +3,15 @@ import { Router } from "./Router/Router";
 console.log("Starting server...");
 
 const port = 3000;
-const router = new Router();
-
-router.static("./public");
-router.notFound(() => "404, not found");
-
-router.route("GET", "/", () => {
-  return "index reached";
-});
+const { response } = new Router()
+  .static("./public")
+  .notFound(() => "404, not found")
+  .route("GET", "/", () => {
+    return "index reached";
+  });
 
 export default {
-  fetch: router.response,
+  fetch: response,
   port,
 };
 


### PR DESCRIPTION
## Summary
In this PR I've refactored the Router class to follow the decorator pattern.

## Testing
Created a `testForDecorator(method, ...args)` function to be dropped in at the start of each method test. This function adds a check to ensure the method returns a Router instance.