### PR TITLE
chore: split server & client actions into separate jobs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,34 +19,16 @@ jobs:
           bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  server:
-    needs: build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./server
-    steps:
-      - name: Github checkout
-        uses: actions/checkout@v2
+      - name: Server/Client
+        strategy:
+          matrix:
+            directory: [./server, ./client]
+        defaults:
+          run:
+            working-directory: ${{ matrix.directory }}
+        steps:
+          - name: Install dependencies
+            run: bun install
 
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run tests
-        run: bun run test
-
-  client:
-    needs: build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./client
-    steps:
-      - name: Github checkout
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run tests
-        run: bun run test
+          - name: Run tests
+            run: bun run test

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,34 +12,37 @@ jobs:
     steps:
       - name: Github checkout
         uses: actions/checkout@v2
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v0.1.8
         with:
           bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Server Dependencies
-        working-directory: ./server
-        run: bun install
-      - name: Install Client dependencies
-        working-directory: ./client
-        run: bun install
+
   server:
     needs: build
     runs-on: ubuntu-latest
     defaults:
       working-directory: ./server
     steps:
+      - name: Github checkout
+        uses: actions/checkout@v2
+
       - name: Install dependencies
         run: bun install
 
       - name: Run tests
         run: bun run test
+
   client:
     needs: build
     runs-on: ubuntu-latest
     defaults:
       working-directory: ./client
     steps:
+      - name: Github checkout
+        uses: actions/checkout@v2
+
       - name: Install dependencies
         run: bun install
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,9 +2,9 @@ name: Bun CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -22,14 +22,16 @@ jobs:
       - name: Install Server Dependencies
         working-directory: ./server
         run: bun install
-            
+
       - name: Install Client dependencies
         working-directory: ./client
         run: bun install
 
   server:
-    needs: build 
-    working-directory: ./server
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      working-directory: ./server
     steps:
       - name: Install dependencies
         run: bun install
@@ -38,12 +40,13 @@ jobs:
         run: bun run test
 
   client:
-    needs: build 
-    working-directory: ./client
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      working-directory: ./client
     steps:
       - name: Install dependencies
         run: bun install
 
       - name: Run tests
         run: bun run test
-

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [./server, ./client]
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
     steps:
       - name: Github checkout
         uses: actions/checkout@v2
@@ -19,16 +25,8 @@ jobs:
           bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Server/Client
-        strategy:
-          matrix:
-            directory: [./server, ./client]
-        defaults:
-          run:
-            working-directory: ${{ matrix.directory }}
-        steps:
-          - name: Install dependencies
-            run: bun install
+      - name: Install dependencies
+        run: bun install
 
-          - name: Run tests
-            run: bun run test
+      - name: Run tests
+        run: bun run test

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,15 +22,28 @@ jobs:
       - name: Install Server Dependencies
         working-directory: ./server
         run: bun install
-          
-      - name: Testing Server
-        working-directory: ./server
-        run: bun run test
             
       - name: Install Client dependencies
         working-directory: ./client
         run: bun install
 
-      - name: Testing Client
-        working-directory: ./client
+  server:
+    needs: build 
+    working-directory: ./server
+    steps:
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
         run: bun run test
+
+  client:
+    needs: build 
+    working-directory: ./client
+    steps:
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun run test
+

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,21 +12,17 @@ jobs:
     steps:
       - name: Github checkout
         uses: actions/checkout@v2
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v0.1.8
         with:
           bun-version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install Server Dependencies
         working-directory: ./server
         run: bun install
-
       - name: Install Client dependencies
         working-directory: ./client
         run: bun install
-
   server:
     needs: build
     runs-on: ubuntu-latest
@@ -38,7 +34,6 @@ jobs:
 
       - name: Run tests
         run: bun run test
-
   client:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     defaults:
-      working-directory: ./server
+      run:
+        working-directory: ./server
     steps:
       - name: Github checkout
         uses: actions/checkout@v2
@@ -38,7 +39,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     defaults:
-      working-directory: ./client
+      run:
+        working-directory: ./client
     steps:
       - name: Github checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
Attempting to split up server and client build step into separate jobs to speed up the CI pipeline. Ideally, testing for both will be conducted simultaneously.